### PR TITLE
Fix examples in docs

### DIFF
--- a/2-starting/1-creating-server.md
+++ b/2-starting/1-creating-server.md
@@ -50,8 +50,8 @@ const { Server } = require('@logux/server')
 
 const server = new Server(
   Server.loadOptions(process, {
-    subprotocol: '0.1.0',
-    supports: '^0.1.0',
+    subprotocol: '1.0.0',
+    supports: '1.x',
     root: __dirname
   })
 )
@@ -137,8 +137,8 @@ Connect to the database in `index.js`:
 
   const server = new Server(
     Server.loadOptions(process, {
-      subprotocol: '0.1.0',
-      supports: '^0.1.0',
+      subprotocol: '1.0.0',
+      supports: '1.x',
       root: __dirname
     })
   )

--- a/2-starting/2-creating-proxy.md
+++ b/2-starting/2-creating-proxy.md
@@ -48,8 +48,8 @@ const { Server } = require('@logux/server')
 
 const server = new Server(
   Server.loadOptions(process, {
-    subprotocol: '0.1.0',
-    supports: '^0.1.0',
+    subprotocol: '1.0.0',
+    supports: '1.x',
     root: __dirname
   })
 )

--- a/2-starting/3-creating-redux.md
+++ b/2-starting/3-creating-redux.md
@@ -85,7 +85,7 @@ Edit `src/index.js`:
 + import createLoguxCreator from '@logux/redux/create-logux-creator';
 
 + const createStore = createLoguxCreator({
-+   subprotocol: '0.1.0',
++   subprotocol: '1.0.0',
 +   server: process.env.NODE_ENV === 'development'
 +     ? 'ws://localhost:31337'
 +     : 'wss://logux.example.com',

--- a/2-starting/4-replacing-redux.md
+++ b/2-starting/4-replacing-redux.md
@@ -38,7 +38,7 @@ Find store definition in your project. Look for `createStore` function call. Oft
 
 ```diff
 + const createStore = createLoguxCreator({
-+   subprotocol: '0.1.0',
++   subprotocol: '1.0.0',
 +   server: process.env.NODE_ENV === 'development'
 +     ? 'ws://localhost:31337'
 +     : 'wss://logux.example.com',

--- a/4-recipes/1-authentication.md
+++ b/4-recipes/1-authentication.md
@@ -99,7 +99,7 @@ Use these `<meta>` values in the store:
 +     : 'https://example.com/login'
 + }
   const createStore = createLoguxCreator({
-    subprotocol: '0.1.0',
+    subprotocol: '1.0.0',
     server: process.env.NODE_ENV === 'development'
       ? 'ws://localhost:31337'
       : 'wss://logux.example.com',
@@ -195,7 +195,7 @@ import Client from '@logux/client/client'
 
 function login (email, password) {
   let client = new Client({
-    subprotocol: '0.1.0',
+    subprotocol: '1.0.0',
     server: process.env.NODE_ENV === 'development'
       ? 'ws://localhost:31337'
       : 'wss://logux.example.com',
@@ -226,7 +226,7 @@ Use these `localStorage` values in the store:
 +     : 'https://example.com/login'
 + };
   const createStore = createLoguxCreator({
-    subprotocol: '0.1.0',
+    subprotocol: '1.0.0',
     server: process.env.NODE_ENV === 'development'
       ? 'ws://localhost:31337'
       : 'wss://logux.example.com',

--- a/4-recipes/1-authentication.md
+++ b/4-recipes/1-authentication.md
@@ -201,7 +201,7 @@ function login (email, password) {
       : 'wss://logux.example.com',
     userId: false
   })
-  client.on('add', action => {
+  client.log.on('add', action => {
     if (action.type === 'login/done') {
       localStorage.setItem('userId', action.userId)
       localStorage.setItem('token', action.token)
@@ -213,7 +213,7 @@ function login (email, password) {
     }
   })
   client.start()
-  client.add({ type: 'login', email, password }, { sync: true })
+  client.log.add({ type: 'login', email, password }, { sync: true })
 })
 ```
 


### PR DESCRIPTION
Fixed bugs in the examples I encountered:

- don't set listeners in auth example;
- out-of-date `subprotocol` version
- out-of-date `supports` version