### PR TITLE
docs: Avoids calling hook conditionally in example

### DIFF
--- a/1-architecture/2-practice.md
+++ b/1-architecture/2-practice.md
@@ -69,10 +69,11 @@ Logux client shows loader while the server loads data. When the client will rece
 ```js
 export const User = ({ userId }) => {
   const isSubscribing = useSubscription(`user/${ userId }`)
+  const user = useSelector(state => state.users[userId])
+
   if (isSubscribing) {
     return <Loader />
   } else {
-    const user = useSelector(state => state.users[userId])
     return <Name>{user.name}</Name>
   }
 }


### PR DESCRIPTION
The reason is https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level

Also thanks for these docs, they've incredibly thorough - excited to try it out!