### PR TITLE
Add userContext to connect action

### DIFF
--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -63,9 +63,9 @@ Clients may receive headers from the server:
 
 ```ts
 CONNECTED
+SERVER < ["headers", { env: "development" }]
 CLIENT > ["connect", 0, "client1", 130, { token: "token" }]
 SERVER < ["connected", 0, "server", [1475316168379, 1475316169987]]
-SERVER < ["headers", { env: "development" }]
 
 CLIENT > ["ping", 0]
 SERVER < ["pong", 0]

--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -57,3 +57,15 @@ CLIENT > ["sync", 4,
 SERVER < ["synced", 4]
 DISCONNECTED
 ```
+
+Clients may update context:
+
+```ts
+CONNECTED
+CLIENT > ["connect", 0, "client1", 130, { token: "token" }]
+SERVER < ["connected", 0, "server", [1475316168379, 1475316169987]]
+
+CLIENT > ["context", 0, { language: 'en' }]
+SERVER < ["synced", 0]
+DISCONNECTED
+```

--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -62,10 +62,8 @@ Clients may update context:
 
 ```ts
 CONNECTED
+CLIENT > ["headers", { language: "pl" }]
 CLIENT > ["connect", 0, "client1", 130, { token: "token" }]
 SERVER < ["connected", 0, "server", [1475316168379, 1475316169987]]
-
-CLIENT > ["context", 0, { language: 'en' }]
-SERVER < ["context", 0, { update: true }]
 DISCONNECTED
 ```

--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -66,6 +66,6 @@ CLIENT > ["connect", 0, "client1", 130, { token: "token" }]
 SERVER < ["connected", 0, "server", [1475316168379, 1475316169987]]
 
 CLIENT > ["context", 0, { language: 'en' }]
-SERVER < ["synced", 0]
+SERVER < ["context", 0, { update: true }]
 DISCONNECTED
 ```

--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -13,6 +13,7 @@ Correct synchronization:
 
 ```ts
 CONNECTED
+CLIENT > ["headers", { language: "pl" }]
 CLIENT > ["connect", 0, "client1", 0, { token: "token" }]
 SERVER < ["connected", 0, "server", [1475316481050, 1475316482879]]
 
@@ -62,8 +63,11 @@ Clients may update context:
 
 ```ts
 CONNECTED
-CLIENT > ["headers", { language: "pl" }]
 CLIENT > ["connect", 0, "client1", 130, { token: "token" }]
 SERVER < ["connected", 0, "server", [1475316168379, 1475316169987]]
+SERVER < ["headers", { env: "development" }]
+
+CLIENT > ["ping", 0]
+SERVER < ["pong", 0]
 DISCONNECTED
 ```

--- a/protocols/ws/examples.md
+++ b/protocols/ws/examples.md
@@ -59,7 +59,7 @@ SERVER < ["synced", 4]
 DISCONNECTED
 ```
 
-Clients may update context:
+Clients may receive headers from the server:
 
 ```ts
 CONNECTED

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -86,7 +86,7 @@ Right now there are 7 possible errors:
 ```
 
 The second position is data object. This object could contain any keys and values.
-After receiving this command receiver doesn't send any messages back.
+After receiving this command receiver doesn’t send any messages back.
 Receiver saved data object for a particular sender.
 
 The sender could send this command multiple times but data will be saved only from the last command.

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -34,6 +34,7 @@ First string in message array is a message type. Possible types:
 * [`pong`]
 * [`sync`]
 * [`synced`]
+* [`context`]
 * [`debug`]
 
 If client received unknown type, it should send `wrong-format` error and continue communication.
@@ -47,6 +48,7 @@ Protocol design has no client and server roles. But in most real cases client wi
 [`ping`]:      #ping
 [`pong`]:      #pong
 [`sync`]:      #sync
+[`context`]:   #context
 [`debug`]:     #debug
 
 
@@ -198,7 +200,7 @@ Received action’s `time` time may be different with sender’s `time`, because
 
 ## `synced`
 
-`synced` message is a answer to [`sync`] message.
+`synced` message is a answer to [`sync`] and [`context`] messages.
 
 ```ts
 [
@@ -208,6 +210,20 @@ Received action’s `time` time may be different with sender’s `time`, because
 ```
 
 Receiver should mark all actions with lower `added` time as synchronized.
+
+## `context`
+
+`context` message contains some user related context data. For example language.
+
+```ts
+[
+  "context",
+  number synced
+  (object data)
+]
+```
+
+Data object could contains any keys and values.
 
 
 ## `debug`

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -87,7 +87,6 @@ Right now there are 7 possible errors:
 
 The second position is data object. This object could contain any keys and values.
 After receiving this command receiver doesn’t send any messages back.
-Receiver saved data object for a particular sender.
 
 The sender could send this command multiple times but data will be saved only from the last command.
 If next `headers` misses some keys from previous command, node should delete these missed keys.

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -76,7 +76,7 @@ Right now there are 7 possible errors:
 
 ## `headers`
 
-`headers` message contains some user related data.
+`headers` message contains custom data about the node. For instance, a user’s locale or server’s environment.
 
 ```ts
 [

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -200,7 +200,7 @@ Received action’s `time` time may be different with sender’s `time`, because
 
 ## `synced`
 
-`synced` message is a answer to [`sync`] and [`context`] messages.
+`synced` message is a answer to [`sync`] message.
 
 ```ts
 [
@@ -213,7 +213,7 @@ Receiver should mark all actions with lower `added` time as synchronized.
 
 ## `context`
 
-`context` message contains some user related context data. For example language.
+`context` message contains some user related context data.
 
 ```ts
 [
@@ -223,7 +223,11 @@ Receiver should mark all actions with lower `added` time as synchronized.
 ]
 ```
 
-Data object could contains any keys and values.
+Second position contains last added time used by receiver in previous connection (0 on first connection). 
+
+Third position contains data object. This object could contains any keys and values.
+
+On `context` command server answer with same command `context` but with data: `{ updated: true }`.
 
 
 ## `debug`

--- a/protocols/ws/spec.md
+++ b/protocols/ws/spec.md
@@ -39,9 +39,9 @@ First string in message array is a message type. Possible types:
 
 If client received unknown type, it should send `wrong-format` error and continue communication.
 
-Protocol design has no client and server roles. But in most real cases client will send `headers`, `connect` and `ping`. Server will send `connected` and `pong`. Both will send `error`, `sync` and `synced`.
+Protocol design has no client and server roles. But in most real cases client will send `connect` and `ping`. Server will send `connected` and `pong`. Both will send `headers`, `error`, `sync` and `synced`.
 
-[`headers`]: #headers
+[`headers`]:   #headers
 [`connected`]: #connected
 [`connect`]:   #connect
 [`synced`]:    #synced
@@ -86,17 +86,11 @@ Right now there are 7 possible errors:
 ```
 
 The second position is data object. This object could contain any keys and values.
-
 After receiving this command receiver doesn't send any messages back.
-
 Receiver saved data object for a particular sender.
 
 The sender could send this command multiple times but data will be saved only from the last command.
-
-Command `headers` valid only before command `connect`.
-
-After the receiver sends command `connected` back sender should not send `headers` anymore.
-
+If next `headers` misses some keys from previous command, node should delete these missed keys.
 
 ## `connect`
 
@@ -233,7 +227,6 @@ Received action’s `time` time may be different with sender’s `time`, because
 ```
 
 Receiver should mark all actions with lower `added` time as synchronized.
-
 
 
 ## `debug`


### PR DESCRIPTION
Regarding to this issue https://github.com/logux/core/issues/30 I want to suggest changes to protocol.

This RFC add key `userContext` to fifth param in `connect` action.