### PR TITLE
Add Vuex typescript recipe example

### DIFF
--- a/recipes/typescript.md
+++ b/recipes/typescript.md
@@ -107,22 +107,40 @@ let store = createStore<CounterState, IncAction>(reducer)
 <details><summary>Vuex client</summary>
 
 ```ts
-type State = number
-
-interface IncrementMutation extends VuexAction {
-  type: 'increment'
+type User = {
+  id: string,
+  name: string
 }
 
+type State = {
+  users: User[]
+}
+
+let Logux = createLogux({ … })
+
 let store = new Logux.Store<State>({
-  state: 0,
+  state: {
+    users: []
+  },
   mutations: {
-    increment (state) {
-      state = state + 1
+    …
+    'user/rename': (state, action) => {
+      state.users = state.users.map(user => {
+        if (user.id === action.userId) {
+          return { ...user, name: action.name }
+        } else {
+          return user
+        }
+      })
     }
   }
 })
 
-store.commit.sync<IncrementMutation>({ type: 'increment' })
+store.commit.sync({
+  type: 'user/rename',
+  userId: '10',
+  name: 'Tom'
+})
 ```
 
 </details>

--- a/recipes/typescript.md
+++ b/recipes/typescript.md
@@ -104,6 +104,28 @@ let store = createStore<CounterState, IncAction>(reducer)
 ```
 
 </details>
+<details><summary>Vuex client</summary>
+
+```ts
+type State = number
+
+interface IncrementMutation extends VuexAction {
+  type: 'increment'
+}
+
+let store = new Logux.Store<State>({
+  state: 0,
+  mutations: {
+    increment (state) {
+      state = state + 1
+    }
+  }
+})
+
+store.commit.sync<IncrementMutation>({ type: 'increment' })
+```
+
+</details>
 <details><summary>Pure JS client</summary>
 
 You need to define user defined type guards for action types:


### PR DESCRIPTION
Resolve logux/vuex#7

Only this way you can use TS in Vuex 3 without decorators or other modules. Other ways are too specific. That's should be enough for today's documentation.