### PR TITLE
Fix "9 kB" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Ask your questions at [community chat] or [commercial support].
 
 [commercial support]: mailto:logux@evilmartians.com
 [community chat]: https://gitter.im/logux/logux
-[**9 kB**]: https://github.com/logux/client/blob/master/package.json#L87-L90
+[**9 kB**]: https://github.com/logux/client/blob/master/package.json#L108-L113
 [CRDT]: https://slides.com/ai/crdt
 
 <a href="https://evilmartians.com/?utm_source=logux-docs">


### PR DESCRIPTION
https://github.com/logux/client/blob/master/package.json has changed since this link was added, so I've updated the link's line numbers to match up with the latest changes.

If this becomes a common problem due to frequent `package.json` changes, it might be worth changing to a permalink (e.g. to the latest release's `package.json`) instead of linking to `master`'s `package.json`. But for now, I'm just fixing what we have.