### PR TITLE
Fix missing nanostores deps in the Readme

### DIFF
--- a/guide/starting/new-redux-client.md
+++ b/guide/starting/new-redux-client.md
@@ -76,7 +76,7 @@ Read [how to use Redux](http://redux.js.org).
 Install Logux Redux:
 
 ```sh
-npm i @logux/core @logux/client @logux/redux
+npm i @logux/core @logux/client @logux/redux nanostores
 ```
 
 Edit `src/index.js`:


### PR DESCRIPTION
https://github.com/logux/client/blob/main/README.md says:
```
npm install @logux/core @logux/client nanostores
```